### PR TITLE
Fix formatting in status message for total accounts display

### DIFF
--- a/AutoBanana.py
+++ b/AutoBanana.py
@@ -448,7 +448,7 @@ class AutoBanana:
             # Construct the status message
             status = (
                 f" | {Fore.MAGENTA}Total games: {Fore.RED}{len(self.config['games'])} {Fore.RESET}"
-                f"| {Fore.MAGENTA}Total accounts: {Fore.RED}{len(self.steam_account_changer.get_steam_login_user_names()) if self.config['switch_steam_accounts'] else "1"} {Fore.RESET}"
+                f"| {Fore.MAGENTA}Total accounts: {Fore.RED}{len(self.steam_account_changer.get_steam_login_user_names()) if self.config['switch_steam_accounts'] else '1'} {Fore.RESET}"
                 f"| {Fore.MAGENTA}Game opened: {Fore.RED}{self.game_open_count} {Fore.RESET}"
                 f"{'times' if self.game_open_count > 1 else 'time'} "
                 f"| {Fore.MAGENTA}Uptime: {Fore.RED}{str(uptime).split('.')[0]}{Fore.RESET}"


### PR DESCRIPTION
This pull request includes a minor change to the `countdown` method in `AutoBanana.py`. The change ensures consistent use of single quotes for string literals within a formatted string. 

* [`AutoBanana.py`](diffhunk://#diff-bc8a8a9ecf42bdee7aec683c1ec4fd1b7d1c665ee198cb2d1dcd368cefca8a4cL451-R451): Updated the conditional expression for `Total accounts` in the status message to use single quotes instead of double quotes for the string `'1'`.

Fixes #44 